### PR TITLE
Remove dumping the userData.

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -56,9 +56,6 @@ function buildUserDataScript(githubRegistrationToken, label) {
   } else {
     core.error('Not supported ec2-base-os.');
   }
-  userData.forEach(data => {
-    core.info(data);
-  });
   
   return userData;
 }


### PR DESCRIPTION
Accidentally, userData dumping was remain in code and this can cause secret leakage. It is used for rare debugging cases, not needed to remain in main codebase.