### PR TITLE
Resolve GitHub runner naming issue.

### DIFF
--- a/src/aws.js
+++ b/src/aws.js
@@ -26,7 +26,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
     }
     
     userData.push(
-      `./config.cmd --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label} --unattended --runasservice`,
+      `./config.cmd --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --name ${config.input.ec2BaseOs}-${label} --token ${githubRegistrationToken} --labels ${label} --unattended --runasservice`,
       '</powershell>',
     );
   }
@@ -50,7 +50,7 @@ function buildUserDataScript(githubRegistrationToken, label) {
     userData.push(
       'export RUNNER_ALLOW_RUNASROOT=1',
       'export DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1',
-      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --token ${githubRegistrationToken} --labels ${label}`,
+      `./config.sh --url https://github.com/${config.githubContext.owner}/${config.githubContext.repo} --name ${config.input.ec2BaseOs}-${label} --token ${githubRegistrationToken} --labels ${label}`,
       './run.sh',
     );
   } else {


### PR DESCRIPTION
In case of creating Windows based GitHub runners, it can happen that the host name (which used default by GH runner process configuration) is the same for all the instances created from the same AMI. To resolve this conflict, just simple use the base OS type and the generated label as the registered name.