### PR TITLE
Include environment tags for easier identification

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -20,10 +20,13 @@ class Config {
     };
 
     const tags = JSON.parse(core.getInput('aws-resource-tags'));
-    this.tagSpecifications = null;
-    if (tags.length > 0) {
-      this.tagSpecifications = [{ResourceType: 'instance', Tags: tags}, {ResourceType: 'volume', Tags: tags}];
-    }
+    // Include some environment tags for easier identification.
+    tags.push({"Key":"Name","Value":"ec2-github-runner"});
+    tags.push({"Key":"GITHUB_RUN_ID","Value":github.context.runId.toString()});
+    tags.push({"Key":"GITHUB_RUN_NUMBER","Value":github.context.runNumber.toString()});
+    tags.push({"Key":"GITHUB_WORKFLOW","Value":github.context.workflow});
+    tags.push({"Key":"GITHUB_REPOSITORY","Value":github.context.repo.repo});
+    this.tagSpecifications = [{ResourceType: 'instance', Tags: tags}, {ResourceType: 'volume', Tags: tags}];
 
     // the values of github.context.repo.owner and github.context.repo.repo are taken from
     // the environment variable GITHUB_REPOSITORY specified in "owner/repo" format and


### PR DESCRIPTION
It is challenging now to identify which workflow created the EC2 instance in AWS for debugging. Include environment tag for easier identification.